### PR TITLE
src/Makefile: support overriding CFLAGS and LDFLAGS; drop stripping.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,11 +1,8 @@
 CC = gcc
-STRIP = strip
 
 CFLAGS = -O3 -mtune=native -march=native
-CFLAGS += -Ilib
-LDFLAGS = -lm
-
-SFLAGS = --strip-all
+override CFLAGS += -Ilib
+override LDFLAGS += -lm
 
 OUT = ryzen_monitor
 
@@ -20,7 +17,6 @@ all: $(OUT)
 
 $(OUT): $(OBJ)
 	$(CC) $(CFLAGS) $(LDFLAGS) -o $(OUT) $(OBJ)
-	$(STRIP) $(SFLAGS) $(OUT)
 
 clean:
 	rm -rf *.o lib/*.o


### PR DESCRIPTION
When bundling ryzen_monitor in distributions such as Gentoo we do want
to maintain the CFLAGS that users choose, same applies for LDFLAGS. This
changes maintain current behavior while now allowing CFLAGS= and LDFLAGS
to be overriden, while ensuring that -llib and -lm are still present
regardless of overrides.

The strip is removed as when packaging it's good to be able to split
debuging symbols and there's no much gain with unconditionally always
stripping them. 64 kB stripped, 67 kB unstripped and users and package
maintainers can still run strip --strip-all while packaging if they
desire.

Signed-off-by: KARBOWSKI Piotr <piotr.karbowski@gmail.com>

Signed-off-by: KARBOWSKI Piotr <piotr.karbowski@gmail.com>