### PR TITLE
Version 1.0.6

### DIFF
--- a/src/pm_tables.c
+++ b/src/pm_tables.c
@@ -312,7 +312,7 @@ void pm_table_0x380805(pm_table *pmt, void* base_addr) {
     pmt->FIT_VOLTAGE                = pm_element(36);
     pmt->FIT_PRE_VOLTAGE            = pm_element(37);
     pmt->LATCHUP_VOLTAGE            = pm_element(38);
-    pmt->CPU_SET_VOLTAGE            = pm_element(39); //os
+    pmt->CPU_SET_VOLTAGE            = pm_element(39); //os6
     pmt->CPU_TELEMETRY_VOLTAGE      = pm_element(40);
     pmt->CPU_TELEMETRY_VOLTAGE2     = pm_element(41);
     pmt->CPU_TELEMETRY_CURRENT      = pm_element(42); //o
@@ -866,7 +866,7 @@ void pm_table_0x400005(pm_table *pmt, void* base_addr) {
     pmt->max_cores = 8; //Number of cores supported by this PM table version
     pmt->max_l3 = 1; //Number of L3 caches supported by this PM table version
     pmt->zen_version = 3; //Zen3
-    pmt->experimental = 1; //Print experimental note
+    pmt->experimental = 0; //Print experimental note
     pmt->powersum_unclear = 1; //No idea how to calculate the total power
     pmt->has_graphics = 1; //Print GFX information
 

--- a/src/readinfo.c
+++ b/src/readinfo.c
@@ -158,6 +158,7 @@ void get_processor_topology(system_info *sysinfo, unsigned int zen_version) {
                 sysinfo->cores_per_ccx = 8;
             }
             sysinfo->enabled_cores_count = 8*(sysinfo->ccds) - count_set_bits(sysinfo->core_disable_map);
+            break;
         case 2:
         default:
             sysinfo->cores_per_ccx = (8 - count_set_bits(sysinfo->core_disable_map & 0xff)) / 2;

--- a/src/readinfo.c
+++ b/src/readinfo.c
@@ -104,7 +104,7 @@ void get_processor_topology(system_info *sysinfo, unsigned int zen_version) {
         //fuse2 += 0x10;
         offs = 0x598;
     }
-    else if (fam == 0x17 && model != 0x71) {
+    else if (fam == 0x17 && model != 0x71 && model != 0x31) {
         fuse1 += 0x40;
         fuse2 += 0x40;
     }
@@ -146,12 +146,18 @@ void get_processor_topology(system_info *sysinfo, unsigned int zen_version) {
         case 3:
             //Zen3 does not have CCXs anymore. They now have 8 cores per CCD
             //each with the same access to each other and the common L3 cache.
-            sysinfo->ccxs = 0;
-            sysinfo->ccds = count_set_bits(ccd_enable_map);
-            sysinfo->cores_per_ccx = 8 - count_set_bits(sysinfo->core_disable_map & 0xff);
-            sysinfo->enabled_cores_count = 8*(sysinfo->ccds) - count_set_bits(sysinfo->core_disable_map);
-            break;
+            if (model != 0x50) {// Exclude Cezanne
+                sysinfo->ccxs = 0;
+                sysinfo->ccds = count_set_bits(ccd_enable_map);
+                sysinfo->cores_per_ccx = 8 - count_set_bits(sysinfo->core_disable_map & 0xff);
+                sysinfo->enabled_cores_count = 8*(sysinfo->ccds) - count_set_bits(sysinfo->core_disable_map);
 
+            } else {
+                sysinfo->core_disable_map = sysinfo->core_disable_map_pmt;
+                sysinfo->ccds = 1;
+                sysinfo->cores_per_ccx = 8;
+            }
+            sysinfo->enabled_cores_count = 8*(sysinfo->ccds) - count_set_bits(sysinfo->core_disable_map);
         case 2:
         default:
             sysinfo->cores_per_ccx = (8 - count_set_bits(sysinfo->core_disable_map & 0xff)) / 2;

--- a/src/readinfo.h
+++ b/src/readinfo.h
@@ -31,6 +31,7 @@ typedef struct {
     unsigned int ccxs;
     unsigned int cores_per_ccx;
     unsigned int core_disable_map;
+    unsigned int core_disable_map_pmt;
     unsigned int enabled_cores_count;
 } system_info;
 


### PR DESCRIPTION
- Bump up version to 1.0.6
- Add support for Cezanne heuristic PM table hack to detect disabled cores
- Fixed fuse offset for Castle Peak
- Removed experimental bit for Cezanne PM table