### PR TITLE
Machine readable output

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,6 +1,6 @@
 CC = gcc
 
-CFLAGS = -O3 -mtune=native -march=native
+CFLAGS = -O3 -mtune=native -march=native -DNDEBUG
 override CFLAGS += -Ilib
 override LDFLAGS += -lm
 
@@ -9,6 +9,7 @@ OUT = ryzen_monitor
 SRC = ryzen_monitor.c
 SRC += pm_tables.c
 SRC += readinfo.c
+SRC += box_drawing_ops.c
 SRC += lib/libsmu.c
 
 OBJ = $(SRC:.c=.o)

--- a/src/Makefile
+++ b/src/Makefile
@@ -10,6 +10,7 @@ SRC = ryzen_monitor.c
 SRC += pm_tables.c
 SRC += readinfo.c
 SRC += box_drawing_ops.c
+SRC += json_ops.c
 SRC += lib/libsmu.c
 
 OBJ = $(SRC:.c=.o)

--- a/src/box_drawing_ops.c
+++ b/src/box_drawing_ops.c
@@ -1,0 +1,296 @@
+/**
+ * Ryzen SMU Userspace Sensor Monitor
+ * Copyright (C) 2020-2021
+ *    Jeffrey Bosboom <jbosboom@jeffreybosboom.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ **/
+
+#include <assert.h>
+#include <stdarg.h>
+#include <stdio.h>
+
+#include "output_ops.h"
+
+static void print_line(const char* label, const char* value_format, ...) {
+    static char buffer[1024];
+    va_list list;
+
+    va_start(list, value_format);
+    vsnprintf(buffer, sizeof(buffer), value_format, list);
+    va_end(list);
+
+    fprintf(stdout, "│ %45s │ %46s │\n", label, buffer);
+}
+
+static _Bool use_control_codes = 0;
+static void box_drawing_init(_Bool repeating, _Bool interactive) {
+    use_control_codes = repeating && interactive;
+    if (use_control_codes)
+        fprintf(stdout, "\e[?25l"); // Hide Cursor
+}
+
+static void box_drawing_cleanup() {
+    if (use_control_codes)
+        fprintf(stdout, "\e[?25h"); // Show Cursor
+}
+
+static void box_drawing_begin() {
+    if (use_control_codes)
+        fprintf(stdout, "\e[1;1H\e[2J"); //Move cursor to (1,1); Clear entire screen
+}
+
+static void box_drawing_end() {
+    fflush(stdout);
+}
+
+static const char* const group_begin_strings[] = {
+    [GROUP_SYSINFO] = "╭───────────────────────────────────────────────┬────────────────────────────────────────────────╮\n",
+    [GROUP_CORES] = "╭─────────┬────────────┬──────────┬─────────┬──────────┬─────────────┬─────────────┬─────────────╮\n",
+    [GROUP_CORE_STATS_CALC] = "╭── Core Statistics (Calculated) ───────────────┬────────────────────────────────────────────────╮\n",
+    [GROUP_CORE_STATS_SMU] = "├── Reported by SMU ────────────────────────────┼────────────────────────────────────────────────┤\n",
+    [GROUP_LIMITS] = "╭── Electrical & Thermal Constraints ───────────┬────────────────────────────────────────────────╮\n",
+    [GROUP_MEMORY] = "╭── Memory Interface ───────────────────────────┬────────────────────────────────────────────────╮\n",
+    [GROUP_GRAPHICS] = "╭── Graphics Subsystem──────────────────────────┬────────────────────────────────────────────────╮\n",
+    [GROUP_POWER] = "╭── Power Consumption ──────────────────────────┬────────────────────────────────────────────────╮\n",
+    [GROUP_POWER_REPORTS] = "├── Additional Reports ─────────────────────────┼────────────────────────────────────────────────┤\n",
+};
+
+static const char usual_end_string[] = "╰───────────────────────────────────────────────┴────────────────────────────────────────────────╯\n";
+static const char* const group_end_strings[] = {
+    [GROUP_SYSINFO] = usual_end_string,
+    [GROUP_CORES] = "╰─────────┴────────────┴──────────┴─────────┴──────────┴─────────────┴─────────────┴─────────────╯\n",
+    [GROUP_CORE_STATS_CALC] = "",
+    [GROUP_CORE_STATS_SMU] = usual_end_string,
+    [GROUP_LIMITS] = usual_end_string,
+    [GROUP_MEMORY] = usual_end_string,
+    [GROUP_GRAPHICS] = usual_end_string,
+    [GROUP_POWER] = "",
+    [GROUP_POWER_REPORTS] = usual_end_string,
+};
+
+static void box_drawing_begin_group(enum group group) {
+    fprintf(stdout, "%s", group_begin_strings[group]);
+}
+
+static void box_drawing_end_group(enum group group) {
+    fprintf(stdout, "%s", group_end_strings[group]);
+}
+
+static const char* const datum_strings[] = {
+    [DATUM_MODEL] = "CPU Model",
+    [DATUM_CODENAME] = "Processor Code Name",
+    [DATUM_CORES] = "Cores",
+    [DATUM_CCDS] = "Core CCDs",
+    [DATUM_CCXS] = "Core CCXs",
+    [DATUM_CORES_PER_CCX] = "Cores Per CCX",
+    [DATUM_CORES_PER_CCD] = "Cores Per CCD",
+    [DATUM_SMU_FW_VERSION] = "SMU FW Version",
+    [DATUM_MP1_IF_VERSION] = "MP1 IF Version",
+
+    [DATUM_PEAK_CORE_FREQ] = "Highest Effective Core Frequency",
+    [DATUM_PEAK_CORE_TEMP] = "Highest Core Temperature",
+    [DATUM_PEAK_CORE_VOLTAGE] = "Highest Core Voltage",
+    [DATUM_AVG_CORE_VOLTAGE] = "Average Core Voltage",
+    [DATUM_AVG_CORE_C6] = "Average Core CC6",
+    [DATUM_TOTAL_CORE_POWER] = "Total Core Power Sum",
+
+    [DATUM_PEAK_CORE_VOLTAGE_SMU] = "Peak Core Voltage",
+    [DATUM_PACKAGE_C6_SMU] = "Package CC6",
+
+    [DATUM_PEAK_TEMP] = "Peak Temperature",
+    [DATUM_SOC_TEMP] = "SoC Temperature",
+    [DATUM_GFX_TEMP] = "GFX Temperature",
+    [DATUM_CORE_VRM_VOLTAGE_LIMIT] = "Voltage from Core VRM",
+    [DATUM_PPT_LIMIT] = "PPT",
+    [DATUM_PPT_APU_LIMIT] = "PPT APU",
+    [DATUM_TDC_LIMIT_NOMINAL] = "TDC Value",
+    [DATUM_TDC_LIMIT_ACTUAL] = "TDC Actual",
+    [DATUM_TDC_SOC_LIMIT_NOMINAL] = "TDC Value, SoC only",
+    [DATUM_EDC_LIMIT] = "EDC",
+    [DATUM_EDC_SOC_LIMIT] = "EDC, SoC only",
+    [DATUM_THM_LIMIT] = "THM",
+    [DATUM_THM_SOC_LIMIT] = "THM SoC",
+    [DATUM_THM_GFX_LIMIT] = "THM GFX",
+    [DATUM_FIT_LIMIT] = "FIT",
+
+    [DATUM_MEMORY_COUPLED] = "Coupled Mode",
+    [DATUM_FCLK_AVG] = "Fabric Clock (Average)",
+    [DATUM_FCLK] = "Fabric Clock",
+    [DATUM_UCLK] = "Uncore Clock",
+    [DATUM_MCLK] = "Memory Clock",
+    [DATUM_VDDM] = "cLDO_VDDM",
+    [DATUM_VDDP] = "cLDO_VDDP",
+    [DATUM_VDDG] = "cLDO_VDDG",
+    [DATUM_VDDG_IOD] = "cLDO_VDDG_IOD",
+    [DATUM_VDDG_CCD] = "cLDO_VDDG_CCD",
+
+    [DATUM_GFX_VOLTAGE_ROC_POWER] = "GFX Voltage | ROC Power",
+    [DATUM_GFX_FREQ_REAL_EFF] = "GFX Clock Real | Effective",
+    [DATUM_GFX_BUSY] = "GFX Busy",
+    [DATUM_GFX_EDC_LIMIT_RESIDENCY] = "GFX EDC Limit | Residency",
+    [DATUM_GFX_DISPLAY_COUNT_FPS] = "Display Count | FPS",
+    [DATUM_GFX_DGPU_POWER_FREQ_TARGET_BUSY] = "DGPU Power | Freq Target | Busy",
+
+    [DATUM_VDDR_SOC_POWER] = "VDDCR_SOC Power",
+    [DATUM_IO_VDDR_SOC_POWER] = "IO VDDCR_SOC Power",
+    [DATUM_GMI2_VDDG_POWER] = "GMI2_VDDG Power",
+    [DATUM_ROC_POWER] = "ROC Power",
+    [DATUM_L3_LOGIC_POWER] = "L3 Logic Power",
+    [DATUM_L3_VDDM_POWER] = "L3 VDDM Power",
+    [DATUM_VDDIO_MEM_POWER] = "VDDIO_MEM Power",
+    [DATUM_IOD_VDDIO_MEM_POWER] = "IOD_VDDIO_MEM Power",
+    [DATUM_DDR_VDDP_POWER] = "DDR_VDDP Power",
+    [DATUM_DDR_PHY_POWER] = "DDR Phy Power",
+    [DATUM_VDD18_POWER] = "VDD18 Power",
+    [DATUM_IO_DISPLAY_POWER] = "CPU Display IO Power",
+    [DATUM_IO_USB_POWER] = "CPU USB IO Power",
+    [DATUM_CALC_TOTAL_POWER] = "Calculated Thermal Output",
+
+    [DATUM_SVI2_SOC_POWER] = "SoC Power (SVI2)",
+    [DATUM_SVI2_CORE_POWER] = "Core Power (SVI2)",
+    [DATUM_SMU_CORE_POWER] = "Core Power (SMU)",
+    [DATUM_SMU_SOCKET_POWER] = "Socket Power (SMU)",
+    [DATUM_SMU_PACKAGE_POWER] = "Package Power (SMU)",
+};
+
+static enum datum const blank_line_before[] = {
+    DATUM_VDDIO_MEM_POWER,
+    DATUM_CALC_TOTAL_POWER,
+};
+static void maybe_print_blank_line(enum datum datum) {
+    for (int i = 0; i < sizeof(blank_line_before) / sizeof(blank_line_before[0]); ++i)
+        if (blank_line_before[i] == datum)
+            print_line("", "");
+}
+
+static void box_drawing_datum_string(enum datum datum, const char* value) {
+    print_line(datum_strings[datum], "%s", value);
+}
+
+static void box_drawing_datum_bool(enum datum datum, _Bool value) {
+    box_drawing_datum_string(datum, value ? "ON" : "OFF");
+}
+
+static void box_drawing_datum_int(enum datum datum, int value, enum unit unit) {
+    assert(unit == UNIT_COUNT);
+    print_line(datum_strings[datum], "%d", value);
+}
+
+static void box_drawing_datum_float(enum datum datum, float value, enum unit unit) {
+    maybe_print_blank_line(datum);
+    const char* label = datum_strings[datum];
+    const char* format = "";
+    switch (unit) {
+        case UNIT_COUNT: assert(0 && "datum_float count"); break;
+        case UNIT_RATIO: format = "%6.2f %%"; value *= 100.f; break;
+        case UNIT_MEGAHERTZ: format = "%8.0f MHz"; break;
+        case UNIT_VOLTS: format = "%7.4f V"; break;
+        case UNIT_AMPS: assert(0 && "datum_float amps"); break;
+        case UNIT_WATTS: format = "%7.3f W"; break;
+        case UNIT_CELSIUS: format = "%8.2f C"; break;
+    }
+    print_line(label, format, value);
+}
+
+static void box_drawing_datum_float2(enum datum datum, float value1, enum unit unit1, float value2, enum unit unit2) {
+    const char* label = datum_strings[datum];
+    const char* format = "";
+    if (unit1 == UNIT_VOLTS && unit2 == UNIT_WATTS) format = "%7.4f V | %8.3f W";
+    else if (unit1 == UNIT_MEGAHERTZ && unit2 == UNIT_MEGAHERTZ) format = "%5.f MHz | %6.f MHz";
+    else if (unit1 == UNIT_AMPS && unit2 == UNIT_RATIO) format = "%7.3f A | %8.2f %%";
+    else if (unit1 == UNIT_COUNT && unit2 == UNIT_COUNT) format = "%2.f | %8.2f  ";
+    else {assert(0 && "datum_float2 unhandled unit pair");}
+    if (unit1 == UNIT_RATIO) value1 *= 100.f;
+    if (unit2 == UNIT_RATIO) value2 *= 100.f;
+    print_line(label, format, value1, value2);
+}
+
+static void box_drawing_datum_float3(enum datum datum, float value1, enum unit unit1, float value2, enum unit unit2, float value3, enum unit unit3) {
+    const char* label = datum_strings[datum];
+    const char* format = "";
+    if (unit1 == UNIT_VOLTS && unit2 == UNIT_AMPS && unit3 == UNIT_WATTS) format = "%8.3f V | %7.3f A | %8.3f W";
+    else if (unit1 == UNIT_WATTS && unit2 == UNIT_MEGAHERTZ && unit3 == UNIT_RATIO) format = "%7.3f W | %5.f MHz | %8.2f %%";
+    else {assert(0 && "datum_float3 unhandled unit triple");}
+    if (unit1 == UNIT_RATIO) value1 *= 100.f;
+    if (unit2 == UNIT_RATIO) value2 *= 100.f;
+    if (unit3 == UNIT_RATIO) value3 *= 100.f;
+    print_line(label, format, value1, value2, value3);
+}
+
+static void box_drawing_datum_limit(enum datum datum, float value, float limit, enum unit unit) {
+    const char* label = datum_strings[datum];
+    const char* format = "";
+    switch (unit) {
+        case UNIT_COUNT: format = "%7.f   | %7.f   | %8.2f %%"; break;
+        case UNIT_RATIO: assert(0 && "datum_limit ratio"); break;
+        case UNIT_MEGAHERTZ: assert(0 && "datum_limit megahertz"); break;
+        case UNIT_VOLTS: format = "%7.3f V | %7.3f V | %8.2f %%"; break;
+        case UNIT_AMPS: format = "%7.3f A | %7.f A | %8.2f %%"; break;
+        case UNIT_WATTS: format = "%7.3f W | %7.f W | %8.2f %%"; break;
+        case UNIT_CELSIUS: format = "%7.2f C | %7.f C | %8.2f %%"; break;
+    }
+    print_line(label, format, value, limit, (value / limit) * 100.f);
+}
+
+static void box_drawing_datum_sum(enum datum datum, const float* begin, const float* end, enum unit unit) {
+    if (end - begin == 1)
+        box_drawing_datum_float(datum, *begin, UNIT_WATTS);
+    else if (end - begin == 2)
+        print_line(datum_strings[datum], "%7.3f W + %7.3f W = %7.3f W", begin[0], begin[1], begin[0]+begin[1]);
+    else if (end - begin == 4) {
+        print_line(datum_strings[datum], "%7.3f W + %7.3f W = %7s", begin[0], begin[1], "");
+        print_line("", "%7.3f W + %7.3f W = %7.3f W", begin[2], begin[3], begin[0]+begin[1]+begin[2]+begin[3]);
+    } else {
+        assert(0 && "datum_sum unhandled length");
+        print_line(datum_strings[datum], "unhandled length %d", end - begin);
+    }
+}
+
+static void box_drawing_core(int number, _Bool disabled, _Bool sleeping, float frequency,
+        float power, float voltage, float temperature,
+        float c0_percent, float c1_percent, float c6_percent) {
+    char number_str[8];
+    snprintf(number_str, sizeof(number_str), "Core %d", number);
+
+    char frequency_str_buf[10];
+    const char* frequency_str = frequency_str_buf;
+    if (disabled)
+        frequency_str = "Disabled";
+    else if (sleeping)
+        frequency_str = "Sleeping";
+    else
+        snprintf(frequency_str_buf, sizeof(frequency_str_buf), "%4.f MHz", frequency);
+
+    fprintf(stdout, "│ %7s │ %10s | %6.3f W | %5.3f V | %6.2f C | C0: %5.1f %% | C1: %5.1f %% | C6: %5.1f %% │\n",
+            number_str, frequency_str, power, voltage, temperature, c0_percent, c1_percent, c6_percent);
+}
+
+const struct output_ops box_drawing_ops = {
+    .init = box_drawing_init,
+    .cleanup = box_drawing_cleanup,
+    .begin = box_drawing_begin,
+    .end = box_drawing_end,
+    .begin_group = box_drawing_begin_group,
+    .end_group = box_drawing_end_group,
+    .datum_string = box_drawing_datum_string,
+    .datum_bool = box_drawing_datum_bool,
+    .datum_int = box_drawing_datum_int,
+    .datum_float = box_drawing_datum_float,
+    .datum_float2 = box_drawing_datum_float2,
+    .datum_float3 = box_drawing_datum_float3,
+    .datum_limit = box_drawing_datum_limit,
+    .datum_sum = box_drawing_datum_sum,
+    .core = box_drawing_core,
+};

--- a/src/json_ops.c
+++ b/src/json_ops.c
@@ -1,0 +1,297 @@
+/**
+ * Ryzen SMU Userspace Sensor Monitor
+ * Copyright (C) 2020-2021
+ *    Jeffrey Bosboom <jbosboom@jeffreybosboom.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ **/
+
+#include <assert.h>
+#include <stdio.h>
+
+#include "output_ops.h"
+
+// floats are written with high precision to allow differentiating between
+// values that are similar but different in each sample (probably measured)
+// and values that are exactly the same in each sample (static or calculated).
+
+// JSON does not allow trailing commas, so we write commas before each
+// non-initial element in an object.  This requires remembering whether the
+// current element in each scope is the initial element.  Our objects have only
+// two scope levels (the top level and each group), so we just use two counters
+// instead of a proper stack.
+static int elements_in_top_level, elements_in_group;
+static void maybe_comma(int* counter) {
+    if ((*counter)++)
+        fprintf(stdout, ",");
+}
+
+static void json_init(_Bool repeating, _Bool interactive) {}
+static void json_cleanup() {}
+
+static void json_begin() {
+    fprintf(stdout, "{");
+    elements_in_top_level = 0;
+}
+
+static void json_end() {
+    fprintf(stdout, "}");
+    fflush(stdout);
+}
+
+static void ndjson_end() {
+    json_end();
+    fprintf(stdout, "\n");
+    fflush(stdout);
+}
+
+static const char* const group_keys[] = {
+    [GROUP_SYSINFO] = "sysinfo",
+    [GROUP_CORES] = "cores",
+    [GROUP_CORE_STATS_CALC] = "core_stats_calc",
+    [GROUP_CORE_STATS_SMU] = "core_stats_reports",
+    [GROUP_LIMITS] = "limits",
+    [GROUP_MEMORY] = "memory",
+    [GROUP_GRAPHICS] = "graphics",
+    [GROUP_POWER] = "power",
+    [GROUP_POWER_REPORTS] = "power_reports",
+};
+
+static void json_begin_group(enum group group) {
+    maybe_comma(&elements_in_top_level);
+    if (group == GROUP_CORES)
+        fprintf(stdout, "\"%s\":[", group_keys[group]);
+    else
+        fprintf(stdout, "\"%s\":{", group_keys[group]);
+    elements_in_group = 0;
+}
+
+static void json_end_group(enum group group) {
+    if (group == GROUP_CORES)
+        fprintf(stdout, "]");
+    else
+        fprintf(stdout, "}");
+}
+
+static const char* const datum_keys[] = {
+    [DATUM_MODEL] = "model",
+    [DATUM_CODENAME] = "codename",
+    [DATUM_CORES] = "cores",
+    [DATUM_CCDS] = "ccds",
+    [DATUM_CCXS] = "ccxs",
+    [DATUM_CORES_PER_CCX] = "cores_per_ccx",
+    [DATUM_CORES_PER_CCD] = "cores_per_ccd",
+    [DATUM_SMU_FW_VERSION] = "smu_firmware_version",
+    [DATUM_MP1_IF_VERSION] = "mp1_if_version",
+
+    [DATUM_PEAK_CORE_FREQ] = "peak_freq",
+    [DATUM_PEAK_CORE_TEMP] = "peak_temp",
+    [DATUM_PEAK_CORE_VOLTAGE] = "peak_voltage",
+    [DATUM_AVG_CORE_VOLTAGE] = "avg_voltage",
+    [DATUM_AVG_CORE_C6] = "avg_cc6",
+    [DATUM_TOTAL_CORE_POWER] = "total_power",
+
+    [DATUM_PEAK_CORE_VOLTAGE_SMU] = "smu_peak_voltage",
+    [DATUM_PACKAGE_C6_SMU] = "smu_package_c6",
+
+    [DATUM_PEAK_TEMP] = "peak_temp",
+    [DATUM_SOC_TEMP] = "soc_temp",
+    [DATUM_GFX_TEMP] = "gfx_temp",
+    [DATUM_CORE_VRM_VOLTAGE_LIMIT] = "core_voltage",
+    [DATUM_PPT_LIMIT] = "ppt",
+    [DATUM_PPT_APU_LIMIT] = "ppt_apu",
+    [DATUM_TDC_LIMIT_NOMINAL] = "tdc_nominal",
+    [DATUM_TDC_LIMIT_ACTUAL] = "tdc_actual",
+    [DATUM_TDC_SOC_LIMIT_NOMINAL] = "tdc_soc_nominal",
+    [DATUM_EDC_LIMIT] = "edc",
+    [DATUM_EDC_SOC_LIMIT] = "edc_soc",
+    [DATUM_THM_LIMIT] = "thm",
+    [DATUM_THM_SOC_LIMIT] = "thm_soc",
+    [DATUM_THM_GFX_LIMIT] = "thm_gfx",
+    [DATUM_FIT_LIMIT] = "fit",
+
+    [DATUM_MEMORY_COUPLED] = "coupled",
+    [DATUM_FCLK_AVG] = "fclk_avg",
+    [DATUM_FCLK] = "fclk",
+    [DATUM_UCLK] = "uclk",
+    [DATUM_MCLK] = "mclk",
+    [DATUM_VDDM] = "cldo_vddm",
+    [DATUM_VDDP] = "cldo_vddp",
+    [DATUM_VDDG] = "cldo_vddg",
+    [DATUM_VDDG_IOD] = "cldo_vddg_iod",
+    [DATUM_VDDG_CCD] = "cldo_vddg_ccd",
+
+    [DATUM_GFX_VOLTAGE_ROC_POWER] = "unused (split)",
+    [DATUM_GFX_FREQ_REAL_EFF] = "unused (split)",
+    [DATUM_GFX_BUSY] = "busy",
+    [DATUM_GFX_EDC_LIMIT_RESIDENCY] = "unused (split)",
+    [DATUM_GFX_DISPLAY_COUNT_FPS] = "unused (split)",
+    [DATUM_GFX_DGPU_POWER_FREQ_TARGET_BUSY] = "unused (split)",
+
+    [DATUM_VDDR_SOC_POWER] = "vddr_soc",
+    [DATUM_IO_VDDR_SOC_POWER] = "io_vddr_soc",
+    [DATUM_GMI2_VDDG_POWER] = "gmi2_vddg",
+    [DATUM_ROC_POWER] = "roc",
+    [DATUM_L3_LOGIC_POWER] = "l3_logic",
+    [DATUM_L3_VDDM_POWER] = "l3_vddm",
+    [DATUM_VDDIO_MEM_POWER] = "vddio_mem",
+    [DATUM_IOD_VDDIO_MEM_POWER] = "iod_vddio_mem",
+    [DATUM_DDR_VDDP_POWER] = "ddr_vddp",
+    [DATUM_DDR_PHY_POWER] = "ddr_phy",
+    [DATUM_VDD18_POWER] = "vdd18",
+    [DATUM_IO_DISPLAY_POWER] = "cpu_display_io",
+    [DATUM_IO_USB_POWER] = "cpu_usb_io",
+    [DATUM_CALC_TOTAL_POWER] = "calc_total",
+
+    [DATUM_SVI2_SOC_POWER] = "svi2_soc",
+    [DATUM_SVI2_CORE_POWER] = "svi2_core",
+    [DATUM_SMU_CORE_POWER] = "smu_core_power",
+    [DATUM_SMU_SOCKET_POWER] = "smu_socket_power",
+    [DATUM_SMU_PACKAGE_POWER] = "smu_package_power",
+};
+
+static const struct split_datum {
+    enum datum datum;
+    const char *key1, *key2, *key3;
+} split_datums[] = {
+    {DATUM_GFX_VOLTAGE_ROC_POWER, "voltage", "roc_power", NULL},
+    {DATUM_GFX_FREQ_REAL_EFF, "freq", "freq_effective", NULL},
+    {DATUM_GFX_EDC_LIMIT_RESIDENCY, "edc_limit", "edc_residency", ""},
+    {DATUM_GFX_DISPLAY_COUNT_FPS, "display_count", "fps", ""},
+    {DATUM_GFX_DGPU_POWER_FREQ_TARGET_BUSY, "dgpu_power", "dgpu_freq_target", "dgpu_busy"},
+};
+
+static const struct fused_datum_subkeys {
+    enum datum datum;
+    const char *key1, *key2, *key3;
+} fused_datum_subkeys[] = {
+    {DATUM_SVI2_SOC_POWER, "voltage", "current", "power"},
+    {DATUM_SVI2_CORE_POWER, "voltage", "current", "power"},
+};
+
+static void json_datum_string(enum datum datum, const char* value) {
+    maybe_comma(&elements_in_group);
+    fprintf(stdout, "\"%s\":\"%s\"", datum_keys[datum], value);
+}
+
+static void json_datum_bool(enum datum datum, _Bool value) {
+    maybe_comma(&elements_in_group);
+    fprintf(stdout, "\"%s\":%s", datum_keys[datum], value ? "true" : "false");
+}
+
+static void json_datum_int(enum datum datum, int value, enum unit unit) {
+    maybe_comma(&elements_in_group);
+    fprintf(stdout, "\"%s\":%d", datum_keys[datum], value);
+}
+
+static void json_single_labeled_float(const char* label, float value) {
+    maybe_comma(&elements_in_group);
+    fprintf(stdout, "\"%s\":%.17f", label, value);
+}
+
+static void json_datum_float(enum datum datum, float value, enum unit unit) {
+    json_single_labeled_float(datum_keys[datum], value);
+}
+
+static void json_datum_float3(enum datum datum, float value1, enum unit unit1, float value2, enum unit unit2, float value3, enum unit unit3) {
+    for (int i = 0; i < sizeof(split_datums)/sizeof(split_datums[0]); ++i)
+        if (split_datums[i].datum == datum) {
+            if (split_datums[i].key1) json_single_labeled_float(split_datums[i].key1, value1);
+            if (split_datums[i].key2) json_single_labeled_float(split_datums[i].key2, value2);
+            if (split_datums[i].key3) json_single_labeled_float(split_datums[i].key3, value3);
+            return;
+        }
+    for (int i = 0; i < sizeof(fused_datum_subkeys)/sizeof(fused_datum_subkeys[0]); ++i)
+        if (fused_datum_subkeys[i].datum == datum) {
+            maybe_comma(&elements_in_group);
+            fprintf(stdout, "\"%s\":{\"%s\":%.17f,\"%s\":%.17f,\"%s\":%.17f}", datum_keys[datum],
+                    fused_datum_subkeys[i].key1, value1,
+                    fused_datum_subkeys[i].key2, value2,
+                    fused_datum_subkeys[i].key3, value3);
+            return;
+        }
+    assert(0);
+}
+
+static void json_datum_float2(enum datum datum, float value1, enum unit unit1, float value2, enum unit unit2) {
+    json_datum_float3(datum, value1, unit1, value2, unit2, 0.f, UNIT_COUNT);
+}
+
+static void json_datum_limit(enum datum datum, float value, float limit, enum unit unit) {
+    maybe_comma(&elements_in_group);
+    fprintf(stdout, "\"%s\":{\"value\":%.17f,\"limit\":%.17f,\"usage\":%.17f}",
+            datum_keys[datum], value, limit, value / limit);
+}
+
+static void json_datum_sum(enum datum datum, const float* begin, const float* end, enum unit unit) {
+    maybe_comma(&elements_in_group);
+    if (end - begin == 1)
+        fprintf(stdout, "\"%s\":{\"values\":[%.17f],\"sum\":%.17f}", datum_keys[datum], begin[0], begin[0]);
+    else if (end - begin == 2)
+        fprintf(stdout, "\"%s\":{\"values\":[%.17f,%.17f],\"sum\":%.17f}", datum_keys[datum],
+                begin[0], begin[1], begin[0]+begin[1]);
+    else if (end - begin == 4)
+        fprintf(stdout, "\"%s\":{\"values\":[%.17f,%.17f,%.17f,%.17f],\"sum\":%.17f}", datum_keys[datum],
+                begin[0], begin[1], begin[2], begin[3], begin[0]+begin[1]+begin[2]+begin[3]);
+    else
+        assert(0 && "datum_sum unhandled length");
+}
+
+static void json_core(int number, _Bool disabled, _Bool sleeping, float frequency,
+        float power, float voltage, float temperature,
+        float c0_percent, float c1_percent, float c6_percent) {
+    maybe_comma(&elements_in_group);
+    fprintf(stdout, "{\"number\":%d,\"disabled\":%s,\"sleeping\":%s,\"frequency\":%.17f,"
+            "\"power\":%.17f,\"voltage\":%.17f,\"temp\":%.17f,"
+            "\"c0\":%.17f,\"c1\":%.17f,\"c6\":%.17f}",
+            number, disabled ? "true" : "false", sleeping ? "true" : "false", frequency,
+            power, voltage, temperature,
+            c0_percent / 100.f, c1_percent / 100.f, c6_percent / 100.f);
+}
+
+const struct output_ops json_ops = {
+    .init = json_init,
+    .cleanup = json_cleanup,
+    .begin = json_begin,
+    .end = json_end,
+    .begin_group = json_begin_group,
+    .end_group = json_end_group,
+    .datum_string = json_datum_string,
+    .datum_bool = json_datum_bool,
+    .datum_int = json_datum_int,
+    .datum_float = json_datum_float,
+    .datum_float2 = json_datum_float2,
+    .datum_float3 = json_datum_float3,
+    .datum_limit = json_datum_limit,
+    .datum_sum = json_datum_sum,
+    .core = json_core,
+};
+
+const struct output_ops ndjson_ops = {
+    .init = json_init,
+    .cleanup = json_cleanup,
+    .begin = json_begin,
+    .end = ndjson_end,
+    .begin_group = json_begin_group,
+    .end_group = json_end_group,
+    .datum_string = json_datum_string,
+    .datum_bool = json_datum_bool,
+    .datum_int = json_datum_int,
+    .datum_float = json_datum_float,
+    .datum_float2 = json_datum_float2,
+    .datum_float3 = json_datum_float3,
+    .datum_limit = json_datum_limit,
+    .datum_sum = json_datum_sum,
+    .core = json_core,
+};

--- a/src/json_ops.c
+++ b/src/json_ops.c
@@ -19,6 +19,7 @@
 
 #include <assert.h>
 #include <stdio.h>
+#include <time.h>
 
 #include "output_ops.h"
 
@@ -41,8 +42,10 @@ static void json_init(_Bool repeating, _Bool interactive) {}
 static void json_cleanup() {}
 
 static void json_begin() {
-    fprintf(stdout, "{");
-    elements_in_top_level = 0;
+    struct timespec t;
+    clock_gettime(CLOCK_MONOTONIC_RAW, &t);
+    fprintf(stdout, "{\"timestamp\":%ld", t.tv_sec * 1000000000 + t.tv_nsec);
+    elements_in_top_level = 1;
 }
 
 static void json_end() {

--- a/src/output_ops.h
+++ b/src/output_ops.h
@@ -1,0 +1,143 @@
+/**
+ * Ryzen SMU Userspace Sensor Monitor
+ * Copyright (C) 2020-2021
+ *    Jeffrey Bosboom <jbosboom@jeffreybosboom.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ **/
+
+enum group {
+    GROUP_SYSINFO,
+    GROUP_CORES,
+    GROUP_CORE_STATS_CALC,
+    GROUP_CORE_STATS_SMU,
+    GROUP_LIMITS,
+    GROUP_MEMORY,
+    GROUP_GRAPHICS,
+    GROUP_POWER,
+    GROUP_POWER_REPORTS,
+};
+
+enum datum {
+    DATUM_MODEL,
+    DATUM_CODENAME,
+    DATUM_CORES,
+    DATUM_CCDS,
+    DATUM_CCXS,
+    DATUM_CORES_PER_CCX,
+    DATUM_CORES_PER_CCD,
+    DATUM_SMU_FW_VERSION,
+    DATUM_MP1_IF_VERSION,
+
+    DATUM_PEAK_CORE_FREQ,
+    DATUM_PEAK_CORE_TEMP,
+    DATUM_PEAK_CORE_VOLTAGE,
+    DATUM_AVG_CORE_VOLTAGE,
+    DATUM_AVG_CORE_C6,
+    DATUM_TOTAL_CORE_POWER,
+
+    DATUM_PEAK_CORE_VOLTAGE_SMU,
+    DATUM_PACKAGE_C6_SMU,
+
+    DATUM_PEAK_TEMP,
+    DATUM_SOC_TEMP,
+    DATUM_GFX_TEMP,
+    DATUM_CORE_VRM_VOLTAGE_LIMIT,
+    DATUM_PPT_LIMIT,
+    DATUM_PPT_APU_LIMIT,
+    DATUM_TDC_LIMIT_NOMINAL,
+    DATUM_TDC_LIMIT_ACTUAL,
+    DATUM_TDC_SOC_LIMIT_NOMINAL,
+    DATUM_EDC_LIMIT,
+    DATUM_EDC_SOC_LIMIT,
+    DATUM_THM_LIMIT,
+    DATUM_THM_SOC_LIMIT,
+    DATUM_THM_GFX_LIMIT,
+    DATUM_FIT_LIMIT,
+
+    DATUM_MEMORY_COUPLED,
+    DATUM_FCLK_AVG,
+    DATUM_FCLK,
+    DATUM_UCLK,
+    DATUM_MCLK,
+    DATUM_VDDM,
+    DATUM_VDDP,
+    DATUM_VDDG,
+    DATUM_VDDG_IOD,
+    DATUM_VDDG_CCD,
+
+    DATUM_GFX_VOLTAGE_ROC_POWER,
+    DATUM_GFX_FREQ_REAL_EFF,
+    DATUM_GFX_BUSY,
+    DATUM_GFX_EDC_LIMIT_RESIDENCY,
+    DATUM_GFX_DISPLAY_COUNT_FPS,
+    DATUM_GFX_DGPU_POWER_FREQ_TARGET_BUSY,
+
+    DATUM_VDDR_SOC_POWER,
+    DATUM_IO_VDDR_SOC_POWER,
+    DATUM_GMI2_VDDG_POWER,
+    DATUM_ROC_POWER,
+    DATUM_L3_LOGIC_POWER,
+    DATUM_L3_VDDM_POWER,
+    DATUM_VDDIO_MEM_POWER,
+    DATUM_IOD_VDDIO_MEM_POWER,
+    DATUM_DDR_VDDP_POWER,
+    DATUM_DDR_PHY_POWER,
+    DATUM_VDD18_POWER,
+    DATUM_IO_DISPLAY_POWER,
+    DATUM_IO_USB_POWER,
+    DATUM_CALC_TOTAL_POWER,
+
+    DATUM_SVI2_SOC_POWER,
+    DATUM_SVI2_CORE_POWER,
+    DATUM_SMU_CORE_POWER,
+    DATUM_SMU_SOCKET_POWER,
+    DATUM_SMU_PACKAGE_POWER,
+};
+
+enum unit {
+    UNIT_COUNT,
+    UNIT_RATIO,
+    // Most frequencies in the tables are MHz, except for core frequency which
+    // is in GHz.  There's no point in converting to Hz and back.
+    UNIT_MEGAHERTZ,
+    UNIT_VOLTS,
+    UNIT_AMPS,
+    UNIT_WATTS,
+    UNIT_CELSIUS,
+};
+
+struct output_ops {
+    void (*init)(_Bool repeating, _Bool interactive);
+    void (*cleanup)();
+
+    void (*begin)();
+    void (*end)();
+
+    void (*begin_group)(enum group group);
+    void (*end_group)(enum group group);
+
+    void (*datum_string)(enum datum datum, const char* value);
+    void (*datum_bool)(enum datum datum, _Bool value);
+    void (*datum_int)(enum datum datum, int value, enum unit unit);
+    void (*datum_float)(enum datum datum, float value, enum unit unit);
+    void (*datum_float2)(enum datum datum, float value1, enum unit unit1, float value2, enum unit unit2);
+    void (*datum_float3)(enum datum datum, float value1, enum unit unit1, float value2, enum unit unit2, float value3, enum unit unit3);
+    void (*datum_limit)(enum datum datum, float value, float limit, enum unit unit);
+    void (*datum_sum)(enum datum datum, const float* begin, const float* end, enum unit unit);
+
+    void (*core)(int number, _Bool disabled, _Bool sleeping, float frequency, float power, float voltage, float temperature, float c0_percent, float c1_percent, float c6_percent);
+};
+
+extern const struct output_ops box_drawing_ops;

--- a/src/output_ops.h
+++ b/src/output_ops.h
@@ -141,3 +141,5 @@ struct output_ops {
 };
 
 extern const struct output_ops box_drawing_ops;
+extern const struct output_ops json_ops;
+extern const struct output_ops ndjson_ops;

--- a/src/ryzen_monitor.c
+++ b/src/ryzen_monitor.c
@@ -37,23 +37,13 @@
 #include <libsmu.h>
 #include "readinfo.h"
 #include "pm_tables.h"
+#include "output_ops.h"
 
 #define PROGRAM_VERSION "1.0.6"
 
 smu_obj_t obj;
 static int update_time_s = 1;
 static int show_disabled_cores = 0;
-
-void print_line(const char* label, const char* value_format, ...) {
-    static char buffer[1024];
-    va_list list;
-
-    va_start(list, value_format);
-    vsnprintf(buffer, sizeof(buffer), value_format, list);
-    va_end(list);
-
-    fprintf(stdout, "│ %45s │ %46s │\n", label, buffer);
-}
 
 //Helper to access the PM Table elements. If an element doesn't exist in the
 //current PM Table version, it's pointer is set to 0. This helper returns
@@ -62,7 +52,7 @@ void print_line(const char* label, const char* value_format, ...) {
 //Same, but with 0 as return. For summations that should not fail if one value is not present.
 #define pmta0(elem) ((pmt->elem)?(*pmt->elem):0)
 
-void draw_screen(pm_table *pmt, system_info *sysinfo) {
+void draw_screen(pm_table *pmt, system_info *sysinfo, const struct output_ops *ops) {
     //general
     int i, j;
     //core block
@@ -80,21 +70,22 @@ void draw_screen(pm_table *pmt, system_info *sysinfo) {
         fprintf(stdout, "Warning: Support for this PM table version is expermiental. Can't trust anything.\n");
     }
 
+    ops->begin();
+
     if (sysinfo->available) {
-        fprintf(stdout, "╭───────────────────────────────────────────────┬────────────────────────────────────────────────╮\n");
-        print_line("CPU Model", sysinfo->cpu_name);
-        print_line("Processor Code Name", sysinfo->codename);
-        print_line("Cores", "%d", sysinfo->cores);
-        print_line("Core CCDs", "%d", sysinfo->ccds);
-        if (pmt->zen_version!=3) {
-            print_line("Core CCXs", "%d", sysinfo->ccxs);
-            print_line("Cores Per CCX", "%d", sysinfo->cores_per_ccx);
-        }
-        else
-            print_line("Cores Per CCD", "%d", sysinfo->cores_per_ccx); //Zen3 does not have CCXs anymore
-        print_line("SMU FW Version", "v%s", sysinfo->smu_fw_ver);
-        print_line("MP1 IF Version", "v%d", sysinfo->if_ver);
-        fprintf(stdout, "╰───────────────────────────────────────────────┴────────────────────────────────────────────────╯\n");
+        ops->begin_group(GROUP_SYSINFO);
+        ops->datum_string(DATUM_MODEL, sysinfo->cpu_name);
+        ops->datum_string(DATUM_CODENAME, sysinfo->codename);
+        ops->datum_int(DATUM_CORES, sysinfo->cores, UNIT_COUNT);
+        ops->datum_int(DATUM_CCDS, sysinfo->ccds, UNIT_COUNT);
+        if (pmt->zen_version < 3) {
+            ops->datum_int(DATUM_CCXS, sysinfo->ccxs, UNIT_COUNT);
+            ops->datum_int(DATUM_CORES_PER_CCX, sysinfo->cores_per_ccx, UNIT_COUNT);
+        } else
+            ops->datum_int(DATUM_CORES_PER_CCD, sysinfo->cores_per_ccx, UNIT_COUNT); //Zen3 does not have CCXs anymore
+        ops->datum_string(DATUM_SMU_FW_VERSION, sysinfo->smu_fw_ver);
+        ops->datum_int(DATUM_MP1_IF_VERSION, sysinfo->if_ver, UNIT_COUNT);
+        ops->end_group(GROUP_SYSINFO);
     }
 
 
@@ -112,7 +103,7 @@ void draw_screen(pm_table *pmt, system_info *sysinfo) {
         average_voltage = pmta(CPU_TELEMETRY_VOLTAGE);
     }
 
-    fprintf(stdout, "╭─────────┬────────────┬──────────┬─────────┬──────────┬─────────────┬─────────────┬─────────────╮\n");
+    ops->begin_group(GROUP_CORES);
     for (i = 0; i < pmt->max_cores; i++) {
         core_disabled = (sysinfo->core_disable_map >> i)&0x01;
         core_frequency = pmta(CORE_FREQEFF[i]) * 1000.f;
@@ -124,30 +115,14 @@ void draw_screen(pm_table *pmt, system_info *sysinfo) {
             core_voltage = ((1.0 - core_sleep_time) * average_voltage) + (0.2 * core_sleep_time);
         //}
 
-        if (core_disabled) {
-            if (show_disabled_cores)
-                    fprintf(stdout,
-                        "│ %*s %d │   Disabled | %6.3f W | %5.3f V | %6.2f C | C0: %5.1f %% | C1: %5.1f %% | C6: %5.1f %% │\n",
-                    (core_number<10)+4, "Core", core_number, //Print "Core" and its number but right-justified
-                        pmta(CORE_POWER[i]), core_voltage, pmta(CORE_TEMP[i]),
-                        pmta(CORE_C0[i]), pmta(CORE_CC1[i]), pmta(CORE_CC6[i]));
-        }
-        else if (pmta(CORE_C0[i]) >= 6.f) {
-            // AMD denotes a sleeping core as having spent less than 6% of the time in C0.
-            // Source: Ryzen Master
-                fprintf(stdout,
-                    "│ %*s %d │   %4.f MHz | %6.3f W | %5.3f V | %6.2f C | C0: %5.1f %% | C1: %5.1f %% | C6: %5.1f %% │\n",
-                (core_number<10)+4, "Core", core_number, //Print "Core" and its number but right-justified
-                core_frequency, pmta(CORE_POWER[i]), core_voltage, pmta(CORE_TEMP[i]),
-                    pmta(CORE_C0[i]), pmta(CORE_CC1[i]), pmta(CORE_CC6[i]));
-            }
-            else {
-                fprintf(stdout,
-                    "│ %*s %d │   Sleeping | %6.3f W | %5.3f V | %6.2f C | C0: %5.1f %% | C1: %5.1f %% | C6: %5.1f %% │\n",
-                (core_number<10)+4, "Core", core_number, //Print "Core" and its number but right-justified
+        // AMD denotes a sleeping core as having spent less than 6% of the time in C0.
+        // Source: Ryzen Master
+        _Bool core_sleeping = pmta(CORE_C0[i]) <= 6.f;
+
+        if (show_disabled_cores || !core_disabled)
+            ops->core(core_number, core_disabled, core_sleeping, core_frequency,
                     pmta(CORE_POWER[i]), core_voltage, pmta(CORE_TEMP[i]),
                     pmta(CORE_C0[i]), pmta(CORE_CC1[i]), pmta(CORE_CC6[i]));
-        }
 
         //Don't confuse people by numbering cores that are disabled and hence not shown on 6 | 12 core CPUs
         //(which actually have 8 | 16 cores)
@@ -164,86 +139,85 @@ void draw_screen(pm_table *pmt, system_info *sysinfo) {
             total_core_CC6 += pmta(CORE_CC6[i]);
         }
     }
+    ops->end_group(GROUP_CORES);
 
-    fprintf(stdout, "╰─────────┴────────────┴──────────┴─────────┴──────────┴─────────────┴─────────────┴─────────────╯\n");
+    ops->begin_group(GROUP_CORE_STATS_CALC);
+    ops->datum_float(DATUM_PEAK_CORE_FREQ, peak_core_frequency, UNIT_MEGAHERTZ);
+    ops->datum_float(DATUM_PEAK_CORE_TEMP, peak_core_temp, UNIT_CELSIUS);
+    ops->datum_float(DATUM_PEAK_CORE_VOLTAGE, peak_core_voltage, UNIT_VOLTS);
+    ops->datum_float(DATUM_AVG_CORE_VOLTAGE, total_core_voltage/sysinfo->enabled_cores_count, UNIT_VOLTS);
+    ops->datum_float(DATUM_AVG_CORE_C6, (total_core_CC6/sysinfo->enabled_cores_count)/100.f, UNIT_RATIO);
+    ops->datum_float(DATUM_TOTAL_CORE_POWER, total_core_power, UNIT_WATTS);
+    ops->end_group(GROUP_CORE_STATS_CALC);
 
-    fprintf(stdout, "╭── Core Statistics (Calculated) ───────────────┬────────────────────────────────────────────────╮\n");
-    print_line("Highest Effective Core Frequency", "%8.0f MHz", peak_core_frequency);
-    print_line("Highest Core Temperature", "%8.2f C", peak_core_temp);
-    print_line("Highest Core Voltage", "%8.3f V", peak_core_voltage);
-    print_line("Average Core Voltage", "%5.3f V", total_core_voltage/sysinfo->enabled_cores_count);
-    print_line("Average Core CC6", "%6.2f %%", total_core_CC6/sysinfo->enabled_cores_count);
-    print_line("Total Core Power Sum", "%7.3f W", total_core_power);
+    ops->begin_group(GROUP_CORE_STATS_SMU);
+    //SOCKET_POWER reported in GROUP_POWER
+    ops->datum_float(DATUM_PEAK_CORE_VOLTAGE_SMU, pmta(CPU_TELEMETRY_VOLTAGE), UNIT_VOLTS);
+    ops->datum_float(DATUM_PACKAGE_C6_SMU, pmta(PC6)/100.f, UNIT_RATIO);
+    ops->end_group(GROUP_CORE_STATS_SMU);
 
-    fprintf(stdout, "├── Reported by SMU ────────────────────────────┼────────────────────────────────────────────────┤\n");
-    //print_line("Package Power", "%8.3f W", pmta(SOCKET_POWER)); //Is listed below in power section
-    print_line("Peak Core Voltage", "%5.3f V", pmta(CPU_TELEMETRY_VOLTAGE));
-    if(pmt->PC6) print_line("Package CC6", "%6.2f %%", pmta(PC6));
-    fprintf(stdout, "╰───────────────────────────────────────────────┴────────────────────────────────────────────────╯\n");
+    ops->begin_group(GROUP_LIMITS);
+    ops->datum_float(DATUM_PEAK_TEMP, pmta(PEAK_TEMP), UNIT_CELSIUS);
+    if (pmt->SOC_TEMP) ops->datum_float(DATUM_SOC_TEMP, pmta(SOC_TEMP), UNIT_CELSIUS);
+    if (pmt->GFX_TEMP) ops->datum_float(DATUM_GFX_TEMP, pmta(GFX_TEMP), UNIT_CELSIUS);
 
-    fprintf(stdout, "╭── Electrical & Thermal Constraints ───────────┬────────────────────────────────────────────────╮\n");
     edc_value = pmta(EDC_VALUE) * (total_usage / sysinfo->cores / 100);
     if (edc_value < pmta(TDC_VALUE)) edc_value = pmta(TDC_VALUE);
 
-    print_line("Peak Temperature", "%8.2f C", pmta(PEAK_TEMP));
-    if(pmt->SOC_TEMP) print_line("SoC Temperature", "%8.2f C", pmta(SOC_TEMP));
-    if(pmt->GFX_TEMP) print_line("GFX Temperature", "%8.2f C", pmta(GFX_TEMP));
-    //print_line("Core Power", "%8.4f W", pmta(VDDCR_CPU_POWER));
+    ops->datum_limit(DATUM_CORE_VRM_VOLTAGE_LIMIT, pmta(VID_VALUE), pmta(VID_LIMIT), UNIT_VOLTS);
+    //STAPM_VALUE / STAPM_LIMIT not reported with no explanation
+    ops->datum_limit(DATUM_PPT_LIMIT, pmta(PPT_VALUE), pmta(PPT_LIMIT), UNIT_WATTS);
+    if (pmt->PPT_VALUE_APU) ops->datum_limit(DATUM_PPT_APU_LIMIT, pmta(PPT_VALUE_APU), pmta(PPT_LIMIT_APU), UNIT_WATTS);
+    ops->datum_limit(DATUM_TDC_LIMIT_NOMINAL, pmta(TDC_VALUE), pmta(TDC_LIMIT), UNIT_AMPS);
+    if (pmt->TDC_ACTUAL) ops->datum_limit(DATUM_TDC_LIMIT_ACTUAL, pmta(TDC_ACTUAL), pmta(TDC_LIMIT), UNIT_AMPS);
+    if (pmt->TDC_VALUE_SOC) ops->datum_limit(DATUM_TDC_SOC_LIMIT_NOMINAL, pmta(TDC_VALUE_SOC), pmta(TDC_LIMIT_SOC), UNIT_AMPS);
+    ops->datum_limit(DATUM_EDC_LIMIT, edc_value, pmta(EDC_LIMIT), UNIT_AMPS);
+    if (pmt->EDC_VALUE_SOC) ops->datum_limit(DATUM_EDC_SOC_LIMIT, pmta(EDC_VALUE_SOC), pmta(EDC_LIMIT_SOC), UNIT_AMPS);
+    ops->datum_limit(DATUM_THM_LIMIT, pmta(THM_VALUE), pmta(THM_LIMIT), UNIT_CELSIUS);
+    if (pmt->THM_VALUE_SOC) ops->datum_limit(DATUM_THM_SOC_LIMIT, pmta(THM_VALUE_SOC), pmta(THM_LIMIT_SOC), UNIT_CELSIUS);
+    if (pmt->THM_VALUE_GFX) ops->datum_limit(DATUM_THM_GFX_LIMIT, pmta(THM_VALUE_GFX), pmta(THM_LIMIT_GFX), UNIT_CELSIUS);
+    // STT_VALUE_APU / STT_LIMIT_APU always zero
+    // STT_VALUE_DGPU / STT_LIMIT_DGPU always zero
+    ops->datum_limit(DATUM_FIT_LIMIT, pmta(FIT_VALUE), pmta(FIT_LIMIT), UNIT_COUNT);
+    ops->end_group(GROUP_LIMITS);
 
-    print_line("Voltage from Core VRM", "%7.3f V | %7.3f V | %8.2f %%", pmta(VID_VALUE), pmta(VID_LIMIT), (pmta(VID_VALUE) / pmta(VID_LIMIT) * 100));
-    //if(pmt->STAPM_VALUE) print_line("STAPM", "%7.3f   | %7.f   | %8.2f %%", pmta(STAPM_VALUE), pmta(STAPM_LIMIT), (pmta(STAPM_VALUE) / pmta(STAPM_LIMIT) * 100));
-    print_line("PPT", "%7.3f W | %7.f W | %8.2f %%", pmta(PPT_VALUE), pmta(PPT_LIMIT), (pmta(PPT_VALUE) / pmta(PPT_LIMIT) * 100));
-    if(pmt->PPT_VALUE_APU) print_line("PPT APU", "%7.3f W | %7.f W | %8.2f %%", pmta(PPT_VALUE_APU), pmta(PPT_LIMIT_APU), (pmta(PPT_VALUE_APU) / pmta(PPT_LIMIT_APU) * 100));
-    print_line("TDC Value", "%7.3f A | %7.f A | %8.2f %%", pmta(TDC_VALUE), pmta(TDC_LIMIT), (pmta(TDC_VALUE) / pmta(TDC_LIMIT) * 100));
-    if(pmt->TDC_ACTUAL) print_line("TDC Actual", "%7.3f A | %7.f A | %8.2f %%", pmta(TDC_ACTUAL), pmta(TDC_LIMIT), (pmta(TDC_ACTUAL) / pmta(TDC_LIMIT) * 100));
-    if(pmt->TDC_VALUE_SOC) print_line("TDC Value, SoC only", "%7.3f A | %7.f A | %8.2f %%", pmta(TDC_VALUE_SOC), pmta(TDC_LIMIT_SOC), (pmta(TDC_VALUE_SOC) / pmta(TDC_LIMIT_SOC) * 100));
-    print_line("EDC", "%7.3f A | %7.f A | %8.2f %%", edc_value, pmta(EDC_LIMIT), (edc_value / pmta(EDC_LIMIT) * 100));
-    if(pmt->EDC_VALUE_SOC) print_line("EDC, SoC only", "%7.3f A | %7.f A | %8.2f %%", pmta(EDC_VALUE_SOC), pmta(EDC_LIMIT_SOC), (pmta(EDC_VALUE_SOC) / pmta(EDC_LIMIT_SOC) * 100));
-    print_line("THM", "%7.2f C | %7.f C | %8.2f %%", pmta(THM_VALUE), pmta(THM_LIMIT), (pmta(THM_VALUE) / pmta(THM_LIMIT) * 100));
-    if(pmt->THM_VALUE_SOC) print_line("THM SoC", "%7.2f C | %7.f C | %8.2f %%", pmta(THM_VALUE_SOC), pmta(THM_LIMIT_SOC), (pmta(THM_VALUE_SOC) / pmta(THM_LIMIT_SOC) * 100));
-    if(pmt->THM_VALUE_GFX) print_line("THM GFX", "%7.2f C | %7.f C | %8.2f %%", pmta(THM_VALUE_GFX), pmta(THM_LIMIT_GFX), (pmta(THM_VALUE_GFX) / pmta(THM_LIMIT_GFX) * 100));
-    //if(pmt->STT_LIMIT_APU) print_line("STT APU", "%7.2f   | %7.f   | %8.2f %%", pmta(STT_VALUE_APU), pmta(STT_LIMIT_APU), (pmta(STT_VALUE_APU) / pmta(STT_LIMIT_APU) * 100)); //Always zero
-    //if(pmt->STT_LIMIT_DGPU) print_line("STT DGPU", "%7.2f   | %7.f   | %8.2f %%", pmta(STT_VALUE_DGPU), pmta(STT_LIMIT_DGPU), (pmta(STT_VALUE_DGPU) / pmta(STT_LIMIT_DGPU) * 100)); //Always zero
-    print_line("FIT", "%7.f   | %7.f   | %8.2f %%", pmta(FIT_VALUE), pmta(FIT_LIMIT), (pmta(FIT_VALUE) / pmta(FIT_LIMIT)) * 100.f);
-    fprintf(stdout, "╰───────────────────────────────────────────────┴────────────────────────────────────────────────╯\n");
+    ops->begin_group(GROUP_MEMORY);
+    ops->datum_bool(DATUM_MEMORY_COUPLED, pmta(UCLK_FREQ) == pmta(MEMCLK_FREQ));
+    ops->datum_float(DATUM_FCLK_AVG, pmta(FCLK_FREQ_EFF), UNIT_MEGAHERTZ);
+    ops->datum_float(DATUM_FCLK, pmta(FCLK_FREQ), UNIT_MEGAHERTZ);
+    ops->datum_float(DATUM_UCLK, pmta(UCLK_FREQ), UNIT_MEGAHERTZ);
+    ops->datum_float(DATUM_MCLK, pmta(MEMCLK_FREQ), UNIT_MEGAHERTZ);
+    // VDDIO_MEM_POWER reported in GROUP_POWER
+    // SOC_SET_VOLTAGE might be the default voltage, not the actually set one
+    ops->datum_float(DATUM_VDDM, pmta(V_VDDM), UNIT_VOLTS);
+    ops->datum_float(DATUM_VDDP, pmta(V_VDDP), UNIT_VOLTS);
+    if (pmt->V_VDDG) ops->datum_float(DATUM_VDDG, pmta(V_VDDG), UNIT_VOLTS);
+    if (pmt->V_VDDG_IOD) ops->datum_float(DATUM_VDDG_IOD, pmta(V_VDDG_IOD), UNIT_VOLTS);
+    if (pmt->V_VDDG_CCD) ops->datum_float(DATUM_VDDG_CCD, pmta(V_VDDG_CCD), UNIT_VOLTS);
+    ops->end_group(GROUP_MEMORY);
 
-    fprintf(stdout, "╭── Memory Interface ───────────────────────────┬────────────────────────────────────────────────╮\n");
-    print_line("Coupled Mode", "%8s", pmta(UCLK_FREQ) == pmta(MEMCLK_FREQ) ? "ON" : "OFF");
-    print_line("Fabric Clock (Average)", "%5.f MHz", pmta(FCLK_FREQ_EFF));
-    print_line("Fabric Clock", "%5.f MHz", pmta(FCLK_FREQ));
-    print_line("Uncore Clock", "%5.f MHz", pmta(UCLK_FREQ));
-    print_line("Memory Clock", "%5.f MHz", pmta(MEMCLK_FREQ));
-    //print_line("VDDCR_Mem", "%7.3f W", pmta(VDDIO_MEM_POWER)); //Is listed below in power section
-    //print_line("VDDCR_SoC", "%7.3f V", pmta(SOC_SET_VOLTAGE)); //Might be the default voltage, not the actually set one
-    print_line("cLDO_VDDM", "%7.4f V", pmta(V_VDDM));
-    print_line("cLDO_VDDP", "%7.4f V", pmta(V_VDDP));
-    if(pmt->V_VDDG)     print_line("cLDO_VDDG", "%7.4f V", pmta(V_VDDG));
-    if(pmt->V_VDDG_IOD) print_line("cLDO_VDDG_IOD", "%7.4f V", pmta(V_VDDG_IOD));
-    if(pmt->V_VDDG_CCD) print_line("cLDO_VDDG_CCD", "%7.4f V", pmta(V_VDDG_CCD));
-    fprintf(stdout, "╰───────────────────────────────────────────────┴────────────────────────────────────────────────╯\n");
-
-    if(pmt->has_graphics){
-    fprintf(stdout, "╭── Graphics Subsystem──────────────────────────┬────────────────────────────────────────────────╮\n");
-    print_line("GFX Voltage | ROC Power", "%7.4f V | %8.3f W", pmta(GFX_VOLTAGE), pmta(ROC_POWER));
-    print_line("GFX Temperature", "%8.2f C", pmta(GFX_TEMP));
-    print_line("GFX Clock Real | Effective", "%5.f MHz | %6.f MHz", pmta(GFX_FREQ), pmta(GFX_FREQEFF));
-    print_line("GFX Busy", "%8.2f %%", pmta(GFX_BUSY) * 100.f);
-    print_line("GFX EDC Limit | Residency", "%7.3f A | %8.2f %%", pmta(GFX_EDC_LIM), pmta(GFX_EDC_RESIDENCY) * 100.f);
-    print_line("Display Count | FPS", "%2.f | %8.2f  ", pmta(DISPLAY_COUNT), pmta(FPS));
-    print_line("DGPU Power | Freq Target | Busy", "%7.3f W | %5.f MHz | %8.2f %%", pmta(DGPU_POWER), pmta(DGPU_FREQ_TARGET), pmta(DGPU_GFX_BUSY) * 100.f);
-    fprintf(stdout, "╰───────────────────────────────────────────────┴────────────────────────────────────────────────╯\n");
+    if (pmt->has_graphics) {
+        ops->begin_group(GROUP_GRAPHICS);
+        ops->datum_float2(DATUM_GFX_VOLTAGE_ROC_POWER, pmta(GFX_VOLTAGE), UNIT_VOLTS, pmta(ROC_POWER), UNIT_WATTS);
+        ops->datum_float(DATUM_GFX_TEMP, pmta(GFX_TEMP), UNIT_CELSIUS);
+        ops->datum_float2(DATUM_GFX_FREQ_REAL_EFF, pmta(GFX_FREQ), UNIT_MEGAHERTZ, pmta(GFX_FREQEFF), UNIT_MEGAHERTZ);
+        ops->datum_float(DATUM_GFX_BUSY, pmta(GFX_BUSY), UNIT_RATIO);
+        ops->datum_float2(DATUM_GFX_EDC_LIMIT_RESIDENCY, pmta(GFX_EDC_LIM), UNIT_AMPS, pmta(GFX_EDC_RESIDENCY), UNIT_RATIO);
+        ops->datum_float2(DATUM_GFX_DISPLAY_COUNT_FPS, pmta(DISPLAY_COUNT), UNIT_COUNT, pmta(FPS), UNIT_COUNT);
+        ops->datum_float3(DATUM_GFX_DGPU_POWER_FREQ_TARGET_BUSY, pmta(DGPU_POWER), UNIT_WATTS, pmta(DGPU_FREQ_TARGET), UNIT_MEGAHERTZ, pmta(DGPU_GFX_BUSY), UNIT_RATIO);
+        ops->end_group(GROUP_GRAPHICS);
     }
 
-    fprintf(stdout, "╭── Power Consumption ──────────────────────────┬────────────────────────────────────────────────╮\n");
+    ops->begin_group(GROUP_POWER);
     //These powers are drawn via VDDCR_SOC and VDDCR_CPU and thus are pulled from the CPU power connector of the mainboard
-    print_line("Total Core Power Sum", "%7.3f W", total_core_power);
-    //print_line("VDDCR_CPU Power", "%7.3f W", pmta(VDDCR_CPU_POWER)); //This value doesn't correlate with what the cores
-                                                                        //report, nor with what is actually consumed. but is
-                                                                        //the value HWiNFO shows.
-    print_line("VDDCR_SOC Power", "%7.3f W", pmta(VDDCR_SOC_POWER));
-    if(pmt->IO_VDDCR_SOC_POWER) print_line("IO VDDCR_SOC Power", "%7.3f W", pmta(IO_VDDCR_SOC_POWER));
-    if(pmt->GMI2_VDDG_POWER) print_line("GMI2_VDDG Power", "%7.3f W", pmta(GMI2_VDDG_POWER));
-    if(pmt->ROC_POWER) print_line("ROC Power", "%7.3f W", pmta(ROC_POWER));
+    ops->datum_float(DATUM_TOTAL_CORE_POWER, total_core_power, UNIT_WATTS);
+    // VDDCR_CPU_POWER doesn't correlate with what the cores report, nor with
+    // what is actually consumed, but is the value HWiNFO shows.  It is
+    // reported in GROUP_POWER_REPORTS.
+    ops->datum_float(DATUM_VDDR_SOC_POWER, pmta(VDDCR_SOC_POWER), UNIT_WATTS);
+    if (pmt->IO_VDDCR_SOC_POWER) ops->datum_float(DATUM_IO_VDDR_SOC_POWER, pmta(IO_VDDCR_SOC_POWER), UNIT_WATTS);
+    if (pmt->GMI2_VDDG_POWER) ops->datum_float(DATUM_GMI2_VDDG_POWER, pmta(GMI2_VDDG_POWER), UNIT_WATTS);
+    if (pmt->ROC_POWER) ops->datum_float(DATUM_ROC_POWER, pmta(ROC_POWER), UNIT_WATTS);
 
     //L3 caches (2 per CCD on Zen2, 1 per CCD on Zen3)
     l3_logic_power=0;
@@ -252,61 +226,36 @@ void draw_screen(pm_table *pmt, system_info *sysinfo) {
         l3_logic_power += pmta0(L3_LOGIC_POWER[i]);
         l3_vddm_power += pmta0(L3_VDDM_POWER[i]);
     }
-    if (pmt->max_l3 == 1) {
-        print_line("L3 Logic Power", "%7.3f W", pmta(L3_LOGIC_POWER[0]));
-        print_line("L3 VDDM Power", "%7.3f W", pmta(L3_VDDM_POWER[0]));
-    } else {
-        for (i=0; i<pmt->max_l3; i+=2) {
-            // + sign if needed and first value
-            j = snprintf(strbuf, sizeof(strbuf), "%s%7.3f W", (i?"+ ":""), pmta(L3_LOGIC_POWER[i]));
-            // second value if it exists
-            if (pmt->max_l3-i > 1) j += snprintf(strbuf+j, sizeof(strbuf)-j, " + %7.3f W", pmta(L3_LOGIC_POWER[i+1]));
-            // end of string (sum or nothing)
-            if (pmt->max_l3-i > 2) j += snprintf(strbuf+j, sizeof(strbuf)-j, "            ");
-            else j += snprintf(strbuf+j, sizeof(strbuf)-j, " = %7.3f W", l3_logic_power);
-            // print
-            print_line((i?"":"L3 Logic Power"), "%s", strbuf);
-        }
-        for (i=0; i<pmt->max_l3; i+=2) {
-            // + sign if needed and first value
-            j = snprintf(strbuf, sizeof(strbuf), "%s%7.3f W", (i?"+ ":""), pmta(L3_VDDM_POWER[i]));
-            // second value if it exists
-            if (pmt->max_l3-i > 1) j += snprintf(strbuf+j, sizeof(strbuf)-j, " + %7.3f W", pmta(L3_VDDM_POWER[i+1]));
-            // end of string (sum or nothing)
-            if (pmt->max_l3-i > 2) j += snprintf(strbuf+j, sizeof(strbuf)-j, "            ");
-            else j += snprintf(strbuf+j, sizeof(strbuf)-j, " = %7.3f W", l3_vddm_power);
-            // print
-            print_line((i?"":"L3 VDDM Power"), "%s", strbuf);
-        }
-    }
+    ops->datum_sum(DATUM_L3_LOGIC_POWER, pmt->L3_LOGIC_POWER[0], pmt->L3_LOGIC_POWER[0] + pmt->max_l3, UNIT_WATTS);
+    ops->datum_sum(DATUM_L3_VDDM_POWER, pmt->L3_VDDM_POWER[0], pmt->L3_VDDM_POWER[0] + pmt->max_l3, UNIT_WATTS);
 
     //These powers are supplied by other power lines to the CPU and are drawn from the 24 pin ATX connector on most boards
-    print_line("","");
-    print_line("VDDIO_MEM Power", "%7.3f W", pmta(VDDIO_MEM_POWER));
-    print_line("IOD_VDDIO_MEM Power", "%7.3f W", pmta(IOD_VDDIO_MEM_POWER));
-    if(pmt->DDR_VDDP_POWER) print_line("DDR_VDDP Power", "%7.3f W", pmta(DDR_VDDP_POWER));
-    if(pmt->DDR_PHY_POWER) print_line("DDR Phy Power", "%7.3f W", pmta(DDR_PHY_POWER));
-    print_line("VDD18 Power", "%7.3f W", pmta(VDD18_POWER)); //Same as pmta(IO_VDD18_POWER)
-    if(pmt->IO_DISPLAY_POWER) print_line("CPU Display IO Power", "%7.3f W", pmta(IO_DISPLAY_POWER));
-    if(pmt->IO_USB_POWER) print_line("CPU USB IO Power", "%7.3f W", pmta(IO_USB_POWER));
+    ops->datum_float(DATUM_VDDIO_MEM_POWER, pmta(VDDIO_MEM_POWER), UNIT_WATTS);
+    ops->datum_float(DATUM_IOD_VDDIO_MEM_POWER, pmta(IOD_VDDIO_MEM_POWER), UNIT_WATTS);
+    if (pmt->DDR_VDDP_POWER) ops->datum_float(DATUM_DDR_VDDP_POWER, pmta(DDR_VDDP_POWER), UNIT_WATTS);
+    if (pmt->DDR_PHY_POWER) ops->datum_float(DATUM_DDR_PHY_POWER, pmta(DDR_PHY_POWER), UNIT_WATTS);
+    ops->datum_float(DATUM_VDD18_POWER, pmta(VDD18_POWER), UNIT_WATTS); //Same as pmta(IO_VDD18_POWER)
+    if (pmt->IO_DISPLAY_POWER) ops->datum_float(DATUM_IO_DISPLAY_POWER, pmta(IO_DISPLAY_POWER), UNIT_WATTS);
+    if (pmt->IO_USB_POWER) ops->datum_float(DATUM_IO_USB_POWER, pmta(IO_USB_POWER), UNIT_WATTS);
 
-    if(!pmt->powersum_unclear) {
-    //The sum is the thermal output of the whole package. Yes, this is higher than PPT and SOCKET_POWER.
-    //Confirmed by measuring the actual current draw on the mainboard.
-    print_line("","");
-    print_line("Calculated Thermal Output", "%7.3f W", total_core_power + pmta0(VDDCR_SOC_POWER) + pmta0(GMI2_VDDG_POWER) 
-            + l3_logic_power + l3_vddm_power
-            + pmta0(VDDIO_MEM_POWER) + pmta0(IOD_VDDIO_MEM_POWER) + pmta0(DDR_VDDP_POWER) + pmta0(VDD18_POWER));
-    }
+    if (!pmt->powersum_unclear)
+        //The sum is the thermal output of the whole package. Yes, this is higher than PPT and SOCKET_POWER.
+        //Confirmed by measuring the actual current draw on the mainboard.
+        ops->datum_float(DATUM_CALC_TOTAL_POWER, total_core_power + pmta0(VDDCR_SOC_POWER) + pmta0(GMI2_VDDG_POWER)
+                + l3_logic_power + l3_vddm_power
+                + pmta0(VDDIO_MEM_POWER) + pmta0(IOD_VDDIO_MEM_POWER) + pmta0(DDR_VDDP_POWER) + pmta0(VDD18_POWER), UNIT_WATTS);
+    ops->end_group(GROUP_POWER);
 
-    fprintf(stdout, "├── Additional Reports ─────────────────────────┼────────────────────────────────────────────────┤\n");
-    //print_line("ROC_POWER", "%7.4f",pmta(ROC_POWER));
-    print_line("SoC Power (SVI2)", "%8.3f V | %7.3f A | %8.3f W", pmta(SOC_TELEMETRY_VOLTAGE), pmta(SOC_TELEMETRY_CURRENT), pmta(SOC_TELEMETRY_POWER));
-    print_line("Core Power (SVI2)", "%8.3f V | %7.3f A | %8.3f W", pmta(CPU_TELEMETRY_VOLTAGE), pmta(CPU_TELEMETRY_CURRENT), pmta(CPU_TELEMETRY_POWER));
-    print_line("Core Power (SMU)", "%7.3f W", pmta(VDDCR_CPU_POWER));
-    print_line("Socket Power (SMU)", "%7.3f W", pmta(SOCKET_POWER));
-    if (pmt->PACKAGE_POWER) print_line("Package Power (SMU)", "%7.3f W", pmta(PACKAGE_POWER));
-    fprintf(stdout, "╰───────────────────────────────────────────────┴────────────────────────────────────────────────╯\n");
+    ops->begin_group(GROUP_POWER_REPORTS);
+    //ROC_POWER reported in GROUP_GRAPHICS and GROUP_POWER
+    ops->datum_float3(DATUM_SVI2_SOC_POWER, pmta(SOC_TELEMETRY_VOLTAGE), UNIT_VOLTS, pmta(SOC_TELEMETRY_CURRENT), UNIT_AMPS, pmta(SOC_TELEMETRY_POWER), UNIT_WATTS);
+    ops->datum_float3(DATUM_SVI2_CORE_POWER, pmta(CPU_TELEMETRY_VOLTAGE), UNIT_VOLTS, pmta(CPU_TELEMETRY_CURRENT), UNIT_AMPS, pmta(CPU_TELEMETRY_POWER), UNIT_WATTS);
+    ops->datum_float(DATUM_SMU_CORE_POWER, pmta(VDDCR_CPU_POWER), UNIT_WATTS);
+    ops->datum_float(DATUM_SMU_SOCKET_POWER, pmta(SOCKET_POWER), UNIT_WATTS);
+    if (pmt->PACKAGE_POWER) ops->datum_float(DATUM_SMU_PACKAGE_POWER, pmta(PACKAGE_POWER), UNIT_WATTS);
+    ops->end_group(GROUP_POWER_REPORTS);
+
+    ops->end();
 }
 
 int select_pm_table_version(unsigned int version, pm_table *pmt, unsigned char *pm_buf) {
@@ -378,7 +327,7 @@ void signal_interrupt(int sig) {
     }
 }
 
-void start_pm_monitor(unsigned int force) {
+void start_pm_monitor(unsigned int force, const struct output_ops* ops) {
     unsigned char *pm_buf;
     pm_table pmt;
     system_info sysinfo;
@@ -435,22 +384,21 @@ void start_pm_monitor(unsigned int force) {
         default:            sysinfo.if_ver =  0; break;
     }
 
+    ops->init(1, isatty(fileno(stdout)));
+
     while (!stop_requested) {
         if (smu_read_pm_table(&obj, pm_buf, obj.pm_table_size) != SMU_Return_OK)
             continue;
 
-        fprintf(stdout, "\e[1;1H\e[2J"); //Move cursor to (1,1); Clear entire screen
-        draw_screen(&pmt, &sysinfo);
-        fprintf(stdout, "\e[?25l"); // Hide Cursor
-        fflush(stdout);
+        draw_screen(&pmt, &sysinfo, ops);
 
         sleep(update_time_s);
     }
 
-    fprintf(stdout, "\e[?25h"); // Show Cursor
+    ops->cleanup();
 }
 
-void read_from_dumpfile(char *dumpfile, unsigned int version) {
+void read_from_dumpfile(char *dumpfile, unsigned int version, const struct output_ops* ops) {
     unsigned char readbuf[10240];
     unsigned int bytes_read;
     pm_table pmt;
@@ -489,7 +437,9 @@ void read_from_dumpfile(char *dumpfile, unsigned int version) {
     sysinfo.core_disable_map=0;
     sysinfo.cores=sysinfo.enabled_cores_count;
 
-    draw_screen(&pmt, &sysinfo);
+    ops->init(0, isatty(fileno(stdout)));
+    draw_screen(&pmt, &sysinfo, ops);
+    ops->cleanup();
 }
 
 void print_version() {
@@ -569,7 +519,7 @@ int main(int argc, char** argv) {
     }
 
     if(dumpfile && !printtimings)
-        read_from_dumpfile(dumpfile, force);
+        read_from_dumpfile(dumpfile, force, &box_drawing_ops);
     else
     {
         if (getuid() != 0 && geteuid() != 0) {
@@ -584,7 +534,7 @@ int main(int argc, char** argv) {
         }
 
         if(printtimings) print_memory_timings();
-        else start_pm_monitor(force);
+        else start_pm_monitor(force, &box_drawing_ops);
     }
 
     return 0;


### PR DESCRIPTION
This implements machine-readable JSON and newline-delimited JSON output, as I requested in #15.  It creates an output abstraction based on groups that contain data.  A datum corresponds to an output line in the standard box-drawing-character-based output, so some contain two or three actual measurements.  This is logically unsatisfying, but fusing two or three measurements into one line requires state while splitting one datum into two or three measurements does not.

The only change to the current output is that some voltages are printed with an extra digit after the decimal place.

The abstraction introduced in this pull request could be the basis of a compact output that fits in an 80-column terminal by ditching the box-drawing characters, or for selectively hiding groups or individual lines in the output.